### PR TITLE
Fix GAS numeric literal syntax

### DIFF
--- a/gas.js
+++ b/gas.js
@@ -1,15 +1,15 @@
 // GAS version of test.js
 
 const DEFAULT_CONFIG = {
-  initial_supply: 1_000_000_000,
+  initial_supply: 1000000000,
   initial_token_price: 0.03,
   final_token_price: 0.05,
   price_pattern: "random", // 'linear', 'u', 'inverse_u', 'random'
   annual_inflation_rate: 0.05,
   staking_participation_rate: 0.6,
-  user_stake: 1_000_000,
+  user_stake: 1000000,
   compound_staking: true,
-  tx_per_month: 20_000_000,
+  tx_per_month: 20000000,
   avg_gls_per_tx: 0.021,
   gls_to_validator_ratio: 1,
   distribution_ratios: {

--- a/test.js
+++ b/test.js
@@ -1,10 +1,10 @@
-const initial_supply = 1_000_000_000; // 初期発行量 (GLS)
+const initial_supply = 1000000000; // 初期発行量 (GLS)
 const initial_token_price = 0.03; // 初期価格（USD）
 const final_token_price = 0.05;   // 終端価格（USD）
 const price_pattern = "random";  // 'linear', 'u', 'inverse_u', 'random'
 const annual_inflation_rate = 0.05;
 const staking_participation_rate = 0.6;
-const user_stake = 1_000_000;
+const user_stake = 1000000;
 const compound_staking = true;
 
 const distribution_ratios = {
@@ -15,7 +15,7 @@ const distribution_ratios = {
   "管理・予備費": 0.10
 };
 
-const tx_per_month = 20_000_000;
+const tx_per_month = 20000000;
 const avg_gls_per_tx = 0.021;
 const gls_to_validator_ratio = 1;
 


### PR DESCRIPTION
## Summary
- adjust numeric literals in `gas.js` and `test.js` for Google Apps Script compatibility

## Testing
- `node test.js | head -n 5`
- `python3 test.py | head` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684ff3424cac832293d68284f7824fac